### PR TITLE
Use Rust 2021

### DIFF
--- a/source/gosling/Cargo.toml
+++ b/source/gosling/Cargo.toml
@@ -4,6 +4,7 @@ build = "build.rs"
 authors = ["Richard Pospesel <richard@blueprintforfreespeech.net>"]
 version = "0.0.1"
 rust-version = "1.61"
+edition = "2021"
 
 [build-dependencies]
 cbindgen = "0.20.0"

--- a/source/gosling/src/ffi.rs
+++ b/source/gosling/src/ffi.rs
@@ -6,9 +6,9 @@ use std::os::raw::c_char;
 use std::sync::Mutex;
 use anyhow::{Result, bail};
 
-use object_registry::*;
-use define_registry;
-use tor_crypto::*;
+use crate::object_registry::*;
+use crate::define_registry;
+use crate::tor_crypto::*;
 
 
 /// Error Handling

--- a/source/gosling/src/gosling.rs
+++ b/source/gosling/src/gosling.rs
@@ -14,10 +14,10 @@ use rand::RngCore;
 use rand::rngs::OsRng;
 
 // internal modules
-use honk_rpc::*;
-use tor_crypto::*;
-use tor_controller::*;
-use work_manager::*;
+use crate::honk_rpc::*;
+use crate::tor_crypto::*;
+use crate::tor_controller::*;
+use crate::work_manager::*;
 
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(i32)]

--- a/source/gosling/src/honk_rpc.rs
+++ b/source/gosling/src/honk_rpc.rs
@@ -18,7 +18,7 @@ use crypto::digest::Digest;
 
 // internal crates
 #[cfg(test)]
-use test_utils::MemoryStream;
+use crate::test_utils::MemoryStream;
 
 
 #[derive(Debug, Eq, PartialEq)]

--- a/source/gosling/src/honk_rpc.rs
+++ b/source/gosling/src/honk_rpc.rs
@@ -1,7 +1,6 @@
 // standard
 use std::cell::RefCell;
 use std::collections::{HashMap,VecDeque};
-use std::convert::{From, TryFrom, Into};
 use std::fmt::Debug;
 use std::io::{Cursor, ErrorKind};
 use std::option::Option;

--- a/source/gosling/src/lib.rs
+++ b/source/gosling/src/lib.rs
@@ -28,23 +28,6 @@
 
 #[macro_use]
 extern crate lazy_static;
-extern crate static_assertions;
-extern crate bson;
-extern crate crypto;
-extern crate data_encoding;
-extern crate anyhow;
-extern crate paste;
-extern crate num_enum;
-extern crate rand;
-extern crate rand_core;
-extern crate signature;
-extern crate zeroize;
-extern crate regex;
-extern crate socks;
-extern crate url;
-extern crate tor_llcrypto;
-#[cfg(test)]
-extern crate ntest;
 
 mod ffi;
 mod tor_crypto;

--- a/source/gosling/src/object_registry.rs
+++ b/source/gosling/src/object_registry.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::option::Option;
 use num_enum::TryFromPrimitive;
-use std::convert::TryFrom;
 
 use anyhow::Result;
 

--- a/source/gosling/src/tor_controller.rs
+++ b/source/gosling/src/tor_controller.rs
@@ -31,8 +31,8 @@ use socks::Socks5Stream;
 use url::Host;
 
 // internal modules
-use tor_crypto::*;
-use work_manager::*;
+use crate::tor_crypto::*;
+use crate::work_manager::*;
 
 // get the name of our tor executable
 fn system_tor() -> &'static str {


### PR DESCRIPTION
Rust uses an "Edition" system to manage backward-incompatible changes in the language.  Since gosling requires Rust 1.61, there's no reason not to use the 2021 edition of the language (which has been available since Rust 1.56).

This change makes the code a bit more idiomatic to modern rust programmers; the changes should be pretty small.