### PR TITLE
Clippy fixes

### DIFF
--- a/source/gosling/src/ffi.rs
+++ b/source/gosling/src/ffi.rs
@@ -19,7 +19,7 @@ pub struct Error {
 
 impl Error {
     pub fn new(message: &str) -> Error {
-        return Error{message: CString::new(message).unwrap()};
+        Error{message: CString::new(message).unwrap()}
     }
 }
 
@@ -48,7 +48,7 @@ pub extern "C" fn gosling_error_get_message(error: *const GoslingError) -> *cons
         }
     }
 
-    return ptr::null();
+    ptr::null()
 }
 
 // macro for defining the implmenetation of freeing objects
@@ -126,7 +126,7 @@ fn translate_failures<R,F>(default: R, out_error: *mut *mut GoslingError, closur
     match panic::catch_unwind(closure) {
         // handle success
         Ok(Ok(retval)) => {
-            return retval;
+            retval
         },
         // handle runtime error
         Ok(Err(err)) => {
@@ -135,7 +135,7 @@ fn translate_failures<R,F>(default: R, out_error: *mut *mut GoslingError, closur
                 let key = error_registry().insert(Error::new(format!("{:?}", err).as_str()));
                 unsafe {*out_error = key as *mut GoslingError;};
             }
-            return default;
+            default
         },
         // handle panic
         Err(_) => {
@@ -144,7 +144,7 @@ fn translate_failures<R,F>(default: R, out_error: *mut *mut GoslingError, closur
                 let key = error_registry().insert(Error::new("panic occurred"));
                 unsafe {*out_error = key as *mut GoslingError;};
             }
-            return default;
+            default
         },
     }
 }
@@ -300,6 +300,6 @@ pub extern "C" fn gosling_string_is_valid_v3_onion_service_id(
         }
 
         let service_id_string_slice = unsafe { std::slice::from_raw_parts(service_id_string as *const u8, service_id_string_length) };
-        return Ok(V3OnionServiceId::is_valid(str::from_utf8(service_id_string_slice)?));
+        Ok(V3OnionServiceId::is_valid(str::from_utf8(service_id_string_slice)?))
     })
 }

--- a/source/gosling/src/ffi.rs
+++ b/source/gosling/src/ffi.rs
@@ -179,7 +179,7 @@ pub extern "C" fn gosling_ed25519_private_key_from_keyblob(
         }
 
         let key_blob_view = unsafe { std::slice::from_raw_parts(key_blob as *const u8, key_blob_length) };
-        let key_blob_str = std::str::from_utf8(&key_blob_view)?;
+        let key_blob_str = std::str::from_utf8(key_blob_view)?;
         let private_key = Ed25519PrivateKey::from_key_blob(key_blob_str)?;
 
         let handle = ed25519_private_key_registry().insert(private_key);
@@ -264,7 +264,7 @@ pub extern "C" fn gosling_ed25519_public_key_from_ed25519_private_key(
         let private_key_registry = ed25519_private_key_registry();
         match private_key_registry.get(private_key as usize) {
             Some(private_key) => {
-                let public_key = Ed25519PublicKey::from_private_key(&private_key)?;
+                let public_key = Ed25519PublicKey::from_private_key(private_key)?;
                 unsafe {
                     *out_public_key = ed25519_public_key_registry().insert(public_key) as *mut GoslingEd25519PublicKey;
                 };

--- a/source/gosling/src/gosling.rs
+++ b/source/gosling/src/gosling.rs
@@ -248,7 +248,7 @@ impl<H> IntroductionServerApiSet<H> where H : IntroductionServerHandshake + Defa
                 &self.server_cookie);
 
             // verify proof signature
-            if client_proof_signature.verify(&client_proof, &client_public_key) {
+            if client_proof_signature.verify(&client_proof, client_public_key) {
                 return Ok(());
             } else {
                 return Err(GoslingError::InvalidClientProof);
@@ -287,7 +287,7 @@ impl<H> IntroductionServerApiSet<H> where H : IntroductionServerHandshake + Defa
             _ => return Err(GoslingError::Failure),
         };
 
-        match self.handshake.verify_challenge_response(&endpoint, &challenge, &challenge_response) {
+        match self.handshake.verify_challenge_response(endpoint, challenge, &challenge_response) {
             Some(true) => Ok(self.handshake.get_endpoint_server()),
             Some(false) => Err(GoslingError::InvalidChallengeResponse),
             None => Ok(None),
@@ -323,13 +323,13 @@ impl<H> ApiSet for IntroductionServerApiSet<H> where H : IntroductionServerHands
                 };
 
                 // validate args
-                let client_identity = match V3OnionServiceId::from_string(&client_identity) {
+                let client_identity = match V3OnionServiceId::from_string(client_identity) {
                     Ok(client_identity) => client_identity,
                     Err(_) => return Err(ErrorCode::Runtime(GoslingError::InvalidArgument as i32))
                 };
 
                 // route call
-                let server_cookie = match self.begin_handshake(&version, client_identity) {
+                let server_cookie = match self.begin_handshake(version, client_identity) {
                     // immediate
                     Ok(server_cookie) => server_cookie,
                     // error

--- a/source/gosling/src/gosling.rs
+++ b/source/gosling/src/gosling.rs
@@ -580,7 +580,7 @@ impl EndpointServerApiSet {
         return Err(GoslingError::NotImplemented);
     }
 
-    fn send_client_proof(&mut self, client_cookie: &Vec<u8>, client_proof: &Vec<u8>) -> Result<(), GoslingError> {
+    fn send_client_proof(&mut self, client_cookie: &[u8], client_proof: &[u8]) -> Result<(), GoslingError> {
         return Ok(());
     }
 

--- a/source/gosling/src/honk_rpc.rs
+++ b/source/gosling/src/honk_rpc.rs
@@ -554,7 +554,7 @@ impl Session {
             ensure!(self.pending_data.len() < std::mem::size_of::<i32>());
             let bytes_needed = std::mem::size_of::<i32>() - self.pending_data.len();
             let mut buffer = &mut buffer[0..bytes_needed];
-            match self.reader.read(&mut buffer) {
+            match self.reader.read(buffer) {
                 Err(err) => if err.kind() == ErrorKind::WouldBlock || err.kind() == ErrorKind::TimedOut {
                         Ok(None)
                     } else {
@@ -651,7 +651,7 @@ impl Session {
             };
             let mut left = message;
 
-            self.send_message_impl(&mut left)?;
+            self.send_message_impl(left)?;
             self.send_message_impl(&mut right)?;
         } else {
             self.writer.write_all(&self.message_write_buffer)?;

--- a/source/gosling/src/lib.rs
+++ b/source/gosling/src/lib.rs
@@ -12,7 +12,6 @@
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::len_zero)]
 #![allow(clippy::manual_map)]
-#![allow(clippy::needless_borrow)]
 #![allow(clippy::needless_question_mark)]
 #![allow(clippy::neg_cmp_op_on_partial_ord)]
 #![allow(clippy::nonminimal_bool)]

--- a/source/gosling/src/lib.rs
+++ b/source/gosling/src/lib.rs
@@ -12,13 +12,11 @@
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::len_zero)]
 #![allow(clippy::manual_map)]
-#![allow(clippy::needless_question_mark)]
 #![allow(clippy::neg_cmp_op_on_partial_ord)]
 #![allow(clippy::nonminimal_bool)]
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::redundant_pattern_matching)]
 #![allow(clippy::single_match)]
-#![allow(clippy::unnecessary_unwrap)]
 #![allow(clippy::unused_unit)]
 
 #[macro_use]

--- a/source/gosling/src/lib.rs
+++ b/source/gosling/src/lib.rs
@@ -14,7 +14,6 @@
 #![allow(clippy::manual_map)]
 #![allow(clippy::needless_borrow)]
 #![allow(clippy::needless_question_mark)]
-#![allow(clippy::needless_return)]
 #![allow(clippy::neg_cmp_op_on_partial_ord)]
 #![allow(clippy::nonminimal_bool)]
 #![allow(clippy::redundant_field_names)]

--- a/source/gosling/src/lib.rs
+++ b/source/gosling/src/lib.rs
@@ -23,10 +23,6 @@
 #![allow(clippy::unnecessary_unwrap)]
 #![allow(clippy::unused_unit)]
 
-// These are probably bad and may represent real problems.
-#![allow(clippy::manual_memcpy)]
-#![allow(clippy::ptr_arg)]
-
 #[macro_use]
 extern crate lazy_static;
 extern crate static_assertions;

--- a/source/gosling/src/object_registry.rs
+++ b/source/gosling/src/object_registry.rs
@@ -35,16 +35,15 @@ pub struct ObjectRegistry<T> {
 impl<T> ObjectRegistry<T> where T : HasByteTypeId{
     fn next_key(&mut self) -> usize {
         self.counter = self.counter + 1;
-        let retval = (self.counter << 8) + T::get_byte_type_id();
-        return retval;
+        (self.counter << 8) + T::get_byte_type_id()
     }
 
     pub fn new() -> ObjectRegistry<T> {
-        return ObjectRegistry{map: BTreeMap::new(), counter: 0};
+        ObjectRegistry{map: BTreeMap::new(), counter: 0}
     }
 
     pub fn contains_key(&self, key:usize) -> bool {
-        return self.map.contains_key(&key);
+        self.map.contains_key(&key)
     }
 
     pub fn remove(&mut self, key:usize) -> () {
@@ -56,15 +55,15 @@ impl<T> ObjectRegistry<T> where T : HasByteTypeId{
         if !self.map.insert(key, val).is_none() {
             panic!();
         }
-        return key;
+        key
     }
 
     pub fn get(&self, key:usize) -> Option<&T> {
-        return self.map.get(&key);
+        self.map.get(&key)
     }
 
     pub fn get_mut(&mut self, key:usize) -> Option<&mut T> {
-        return self.map.get_mut(&key);
+        self.map.get_mut(&key)
     }
 }
 
@@ -87,7 +86,7 @@ macro_rules! define_registry {
 
             impl HasByteTypeId for $type {
                 fn get_byte_type_id() -> usize {
-                    return [<$type:snake:upper _BYTE_TYPE_ID>];
+                    [<$type:snake:upper _BYTE_TYPE_ID>]
                 }
             }
         }

--- a/source/gosling/src/tor_controller.rs
+++ b/source/gosling/src/tor_controller.rs
@@ -68,7 +68,7 @@ fn read_control_port_file(control_port_file: &Path) -> Result<SocketAddr> {
 
     if contents.starts_with("PORT=") {
         let addr_string = &contents.trim_end()["PORT=".len()..];
-        return Ok(SocketAddr::from_str(&addr_string)?);
+        return Ok(SocketAddr::from_str(addr_string)?);
     }
     bail!("read_control_port_file(): could not parse '{}' as control port file", control_port_file.display());
 }
@@ -315,7 +315,7 @@ impl ControlStream {
                     // view into byte vec of just the found line
                     let line_view: &[u8] = &self.pending_data[begin..end];
                     // convert to string
-                    let line_string = std::str::from_utf8(&line_view)?.to_string();
+                    let line_string = std::str::from_utf8(line_view)?.to_string();
 
                     // save in pending list
                     self.pending_lines.push_back(line_string);
@@ -461,7 +461,7 @@ impl FromStr for Version {
             static ref TOR_VERSION_PATTERN: Regex = Regex::new(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<micro>\d+)(?P<patch_level>\.\d+){0,1}(?P<status_tag>-[^\s]+){0,1}( \([^\s]+\))*$").unwrap();
         }
 
-        if let Some(caps) = TOR_VERSION_PATTERN.captures(&s) {
+        if let Some(caps) = TOR_VERSION_PATTERN.captures(s) {
             let major = caps.name("major");
             ensure!(major.is_some());
             let major: u32 = major.unwrap().as_str().parse()?;
@@ -643,7 +643,7 @@ impl TorController {
         let mut async_events: Vec<AsyncEvent> = Default::default();
 
         for mut reply in async_replies.iter_mut() {
-            async_events.push(TorController::reply_to_event(&mut reply)?);
+            async_events.push(TorController::reply_to_event(reply)?);
         }
 
         Ok(async_events)
@@ -964,7 +964,7 @@ impl TorController {
 
                         // remove leading/trailing double quote
                         let stripped = &socket_addr[1..socket_addr.len() - 1];
-                        result.push(SocketAddr::from_str(&stripped)?);
+                        result.push(SocketAddr::from_str(stripped)?);
                     }
                     return Ok(result);
                 },
@@ -978,7 +978,7 @@ impl TorController {
         let response = self.getinfo(&["version"])?;
         for (key, value) in response.iter() {
             match key.as_str() {
-                "version" => return Version::from_str(&value),
+                "version" => return Version::from_str(value),
                 _ => {},
             }
         }
@@ -1205,7 +1205,7 @@ impl TorManager {
         }
 
         for mut log_line in self.daemon.wait_log_lines().iter_mut() {
-            self.events.push_back(Event::LogReceived{line: std::mem::take(&mut log_line)});
+            self.events.push_back(Event::LogReceived{line: std::mem::take(log_line)});
         }
 
         Ok(self.events.pop_front())

--- a/source/gosling/src/tor_controller.rs
+++ b/source/gosling/src/tor_controller.rs
@@ -662,7 +662,7 @@ impl TorController {
         }
     }
 
-    fn write_command(&mut self, text: &String) -> Result<Reply> {
+    fn write_command(&mut self, text: &str) -> Result<Reply> {
         self.control_stream.write(text)?;
         return self.wait_sync_reply();
     }

--- a/source/gosling/src/tor_crypto.rs
+++ b/source/gosling/src/tor_crypto.rs
@@ -214,13 +214,13 @@ impl Ed25519PrivateKey {
 
     pub fn sign_message_ex(&self, public_key: &Ed25519PublicKey, message: &[u8]) -> Result<Ed25519Signature> {
 
-        let signature = self.expanded_secret_key.sign(&message, &public_key.public_key);
+        let signature = self.expanded_secret_key.sign(message, &public_key.public_key);
         Ok(Ed25519Signature{signature: signature})
     }
 
     pub fn sign_message(&self, message: &[u8]) -> Result<Ed25519Signature> {
-        let public_key = Ed25519PublicKey::from_private_key(&self)?;
-        Ok(self.sign_message_ex(&public_key, &message)?)
+        let public_key = Ed25519PublicKey::from_private_key(self)?;
+        Ok(self.sign_message_ex(&public_key, message)?)
     }
 
     pub fn get_data(&self) -> [u8; ED25519_PRIVATE_KEY_SIZE] {
@@ -287,7 +287,7 @@ impl Ed25519Signature {
     }
 
     pub fn verify(&self, message: &[u8], public_key: &Ed25519PublicKey) -> bool {
-        if let Ok(()) = public_key.public_key.verify(&message, &self.signature) {
+        if let Ok(()) = public_key.public_key.verify(message, &self.signature) {
             return true;
         }
         false
@@ -378,7 +378,7 @@ impl X25519PublicKey {
 
 impl V3OnionServiceId {
     pub fn from_string(service_id: &str) -> Result<V3OnionServiceId> {
-        if !V3OnionServiceId::is_valid(&service_id) {
+        if !V3OnionServiceId::is_valid(service_id) {
             bail!("V3OnionServiceId::from_string(): '{}' is not a valid v3 onion service id", &service_id);
         }
         Ok(V3OnionServiceId{data: service_id.as_bytes().try_into()?})
@@ -404,7 +404,7 @@ impl V3OnionServiceId {
         }
 
         let mut decoded_service_id = [0u8; V3_ONION_SERVICE_ID_RAW_SIZE];
-        match ONION_BASE32.decode_mut(&service_id.as_bytes(), &mut decoded_service_id) {
+        match ONION_BASE32.decode_mut(service_id.as_bytes(), &mut decoded_service_id) {
             Ok(decoded_byte_count) => {
                 // ensure right size
                 if decoded_byte_count != V3_ONION_SERVICE_ID_RAW_SIZE {

--- a/source/gosling/src/tor_crypto.rs
+++ b/source/gosling/src/tor_crypto.rs
@@ -220,7 +220,7 @@ impl Ed25519PrivateKey {
 
     pub fn sign_message(&self, message: &[u8]) -> Result<Ed25519Signature> {
         let public_key = Ed25519PublicKey::from_private_key(self)?;
-        Ok(self.sign_message_ex(&public_key, message)?)
+        self.sign_message_ex(&public_key, message)
     }
 
     pub fn get_data(&self) -> [u8; ED25519_PRIVATE_KEY_SIZE] {

--- a/source/gosling/src/tor_crypto.rs
+++ b/source/gosling/src/tor_crypto.rs
@@ -387,9 +387,7 @@ impl V3OnionServiceId {
     pub fn from_public_key(public_key: &Ed25519PublicKey) -> Result<V3OnionServiceId> {
         let mut raw_service_id = [0u8; V3_ONION_SERVICE_ID_RAW_SIZE];
 
-        for i in 0..ED25519_PUBLIC_KEY_SIZE {
-            raw_service_id[i] = public_key.get_data()[i];
-        }
+        raw_service_id[..ED25519_PUBLIC_KEY_SIZE].copy_from_slice(&public_key.get_data()[..]);
         let truncated_checksum = calc_truncated_checksum(&public_key.get_data());
         raw_service_id[V3_ONION_SERVICE_ID_CHECKSUM_OFFSET + 0] = truncated_checksum[0];
         raw_service_id[V3_ONION_SERVICE_ID_CHECKSUM_OFFSET + 1] = truncated_checksum[1];
@@ -418,9 +416,7 @@ impl V3OnionServiceId {
                 }
                 // copy public key into own buffer
                 let mut public_key = [0u8; ED25519_PUBLIC_KEY_SIZE];
-                for i in 0..ED25519_PUBLIC_KEY_SIZE {
-                    public_key[i] = decoded_service_id[i];
-                }
+                public_key[..].copy_from_slice(&decoded_service_id[..ED25519_PUBLIC_KEY_SIZE]);
                 // ensure checksum is correct
                 let truncated_checksum = calc_truncated_checksum(&public_key);
                 if truncated_checksum[0] != decoded_service_id[V3_ONION_SERVICE_ID_CHECKSUM_OFFSET + 0] ||

--- a/source/gosling/src/tor_crypto.rs
+++ b/source/gosling/src/tor_crypto.rs
@@ -77,7 +77,7 @@ fn calc_truncated_checksum(public_key: &[u8; ED25519_PUBLIC_KEY_SIZE]) -> [u8; T
     hasher.input(&[0x03u8]);
     hasher.result(&mut hash_bytes);
 
-    return [hash_bytes[0], hash_bytes[1]];
+    [hash_bytes[0], hash_bytes[1]]
 }
 
 // Free functions
@@ -122,7 +122,7 @@ fn hash_tor_password_with_salt(salt: &[u8; S2K_RFC2440_SPECIFIER_LEN], password:
     HEXUPPER.encode_append(salt, &mut hash);
     HEXUPPER.encode_append(&key, &mut hash);
 
-    return Ok(hash);
+    Ok(hash)
 }
 
 pub fn hash_tor_password(password: &str) -> Result<String> {
@@ -131,7 +131,7 @@ pub fn hash_tor_password(password: &str) -> Result<String> {
     OsRng.fill_bytes(&mut salt);
     salt[S2K_RFC2440_SPECIFIER_LEN - 1] = 0x60u8;
 
-    return hash_tor_password_with_salt(&salt, password);
+    hash_tor_password_with_salt(&salt, password)
 }
 
 // Struct deinitions
@@ -173,16 +173,16 @@ impl Ed25519PrivateKey {
     pub fn generate() -> Result<Ed25519PrivateKey> {
         let secret_key = pk::ed25519::SecretKey::generate(&mut rand_core::OsRng.rng_compat());
 
-        return Ok(Ed25519PrivateKey{
+        Ok(Ed25519PrivateKey{
             expanded_secret_key: pk::ed25519::ExpandedSecretKey::from(&secret_key),
-        });
+        })
     }
 
     // according to nickm, any 64 byte string here is allowed
     pub fn from_raw(raw: &[u8; ED25519_PRIVATE_KEY_SIZE]) -> Result<Ed25519PrivateKey> {
-        return Ok(Ed25519PrivateKey{
+        Ok(Ed25519PrivateKey{
             expanded_secret_key: pk::ed25519::ExpandedSecretKey::from_bytes(raw)?,
-        });
+        })
     }
 
     pub fn from_key_blob(key_blob: &str) -> Result<Ed25519PrivateKey> {
@@ -202,35 +202,35 @@ impl Ed25519PrivateKey {
         }
         let private_key_data: [u8; ED25519_PRIVATE_KEY_SIZE] = private_key_data.try_into().unwrap();
 
-        return Ed25519PrivateKey::from_raw(&private_key_data);
+        Ed25519PrivateKey::from_raw(&private_key_data)
     }
 
     pub fn to_key_blob(&self) -> Result<String> {
         let mut key_blob = ED25519_PRIVATE_KEYBLOB_HEADER.to_string();
         key_blob.push_str(&BASE64.encode(&self.expanded_secret_key.to_bytes()));
 
-        return Ok(key_blob);
+        Ok(key_blob)
     }
 
     pub fn sign_message_ex(&self, public_key: &Ed25519PublicKey, message: &[u8]) -> Result<Ed25519Signature> {
 
         let signature = self.expanded_secret_key.sign(&message, &public_key.public_key);
-        return Ok(Ed25519Signature{signature: signature});
+        Ok(Ed25519Signature{signature: signature})
     }
 
     pub fn sign_message(&self, message: &[u8]) -> Result<Ed25519Signature> {
         let public_key = Ed25519PublicKey::from_private_key(&self)?;
-        return Ok(self.sign_message_ex(&public_key, &message)?);
+        Ok(self.sign_message_ex(&public_key, &message)?)
     }
 
     pub fn get_data(&self) -> [u8; ED25519_PRIVATE_KEY_SIZE] {
-        return self.expanded_secret_key.to_bytes();
+        self.expanded_secret_key.to_bytes()
     }
 }
 
 impl PartialEq for Ed25519PrivateKey {
     fn eq(&self, other:&Self) -> bool {
-        return self.get_data().eq(&other.get_data());
+        self.get_data().eq(&other.get_data())
     }
 }
 
@@ -238,9 +238,9 @@ impl PartialEq for Ed25519PrivateKey {
 
 impl Ed25519PublicKey {
     pub fn from_raw(raw: &[u8; ED25519_PUBLIC_KEY_SIZE]) -> Result<Ed25519PublicKey> {
-        return Ok(Ed25519PublicKey{
+        Ok(Ed25519PublicKey{
             public_key: pk::ed25519::PublicKey::from_bytes(raw)?,
-        });
+        })
     }
 
     pub fn from_service_id(service_id: &V3OnionServiceId) -> Result<Ed25519PublicKey> {
@@ -251,19 +251,19 @@ impl Ed25519PublicKey {
             bail!("Ed25519PublicKey::from_service_id(): decoded byte count is '{}', expected '{}'", decoded_byte_count, V3_ONION_SERVICE_ID_RAW_SIZE);
         }
 
-        return Ok(Ed25519PublicKey{
+        Ok(Ed25519PublicKey{
             public_key: pk::ed25519::PublicKey::from_bytes(&decoded_service_id[0..ED25519_PUBLIC_KEY_SIZE])?,
-        });
+        })
     }
 
     pub fn from_private_key(private_key: &Ed25519PrivateKey) -> Result<Ed25519PublicKey> {
-        return Ok(Ed25519PublicKey{
+        Ok(Ed25519PublicKey{
             public_key: pk::ed25519::PublicKey::from(&private_key.expanded_secret_key),
-        });
+        })
     }
 
     pub fn to_base32(&self) -> String {
-        return BASE32.encode(&self.get_data());
+        BASE32.encode(&self.get_data())
     }
 
     pub fn get_data(&self) -> [u8; ED25519_PUBLIC_KEY_SIZE] {
@@ -273,7 +273,7 @@ impl Ed25519PublicKey {
 
 impl PartialEq for Ed25519PublicKey {
     fn eq(&self, other: &Self) -> bool {
-        return self.get_data().eq(&other.get_data());
+        self.get_data().eq(&other.get_data())
     }
 }
 
@@ -281,26 +281,26 @@ impl PartialEq for Ed25519PublicKey {
 
 impl Ed25519Signature {
     pub fn from_raw(raw: &[u8; ED25519_SIGNATURE_SIZE]) -> Result<Ed25519Signature> {
-        return Ok(Ed25519Signature{
+        Ok(Ed25519Signature{
             signature: pk::ed25519::Signature::from_bytes(raw)?,
-        });
+        })
     }
 
     pub fn verify(&self, message: &[u8], public_key: &Ed25519PublicKey) -> bool {
         if let Ok(()) = public_key.public_key.verify(&message, &self.signature) {
             return true;
         }
-        return false;
+        false
     }
 
     pub fn get_data(&self) -> [u8; ED25519_SIGNATURE_SIZE] {
-        return self.signature.to_bytes();
+        self.signature.to_bytes()
     }
 }
 
 impl PartialEq for Ed25519Signature {
     fn eq(&self, other: &Self) -> bool {
-        return self.get_data().eq(&other.get_data());
+        self.get_data().eq(&other.get_data())
     }
 }
 
@@ -308,15 +308,15 @@ impl PartialEq for Ed25519Signature {
 
 impl X25519PrivateKey {
     pub fn generate() -> X25519PrivateKey {
-        return X25519PrivateKey{
+        X25519PrivateKey{
             secret_key: pk::curve25519::StaticSecret::new(rand_core::OsRng.rng_compat()),
-        };
+        }
     }
 
     pub fn from_raw(raw: &[u8; X25519_PRIVATE_KEY_SIZE]) -> X25519PrivateKey {
-        return X25519PrivateKey{
+        X25519PrivateKey{
             secret_key: pk::curve25519::StaticSecret::from(*raw),
-        };
+        }
     }
 
     // a base64 encoded keyblob
@@ -330,28 +330,28 @@ impl X25519PrivateKey {
 
         let private_key_data: [u8; X25519_PRIVATE_KEY_SIZE] = private_key_data.try_into().unwrap();
 
-        return Ok(X25519PrivateKey{
+        Ok(X25519PrivateKey{
             secret_key: pk::curve25519::StaticSecret::from(private_key_data),
-        });
+        })
     }
 
     pub fn to_base64(&self) -> String {
-        return BASE64.encode(&self.secret_key.to_bytes());
+        BASE64.encode(&self.secret_key.to_bytes())
     }
 }
 
 // X25519 Public Key
 impl X25519PublicKey {
     pub fn from_private_key(private_key: &X25519PrivateKey) -> X25519PublicKey {
-        return X25519PublicKey{
+        X25519PublicKey{
             public_key: pk::curve25519::PublicKey::from(&private_key.secret_key),
-        };
+        }
     }
 
     pub fn from_raw(raw: &[u8; X25519_PUBLIC_KEY_SIZE]) -> X25519PublicKey {
-        return X25519PublicKey{
+        X25519PublicKey{
             public_key: pk::curve25519::PublicKey::from(*raw),
-        };
+        }
     }
 
     pub fn from_base32(base32: &str) -> Result<X25519PublicKey> {
@@ -364,13 +364,13 @@ impl X25519PublicKey {
 
         let public_key_data: [u8; X25519_PUBLIC_KEY_SIZE] = public_key_data.try_into().unwrap();
 
-        return Ok(X25519PublicKey{
+        Ok(X25519PublicKey{
             public_key: pk::curve25519::PublicKey::from(public_key_data),
-        });
+        })
     }
 
     pub fn to_base32(&self) -> String {
-        return BASE32_NOPAD.encode(&self.public_key.to_bytes());
+        BASE32_NOPAD.encode(&self.public_key.to_bytes())
     }
 }
 
@@ -381,7 +381,7 @@ impl V3OnionServiceId {
         if !V3OnionServiceId::is_valid(&service_id) {
             bail!("V3OnionServiceId::from_string(): '{}' is not a valid v3 onion service id", &service_id);
         }
-        return Ok(V3OnionServiceId{data: service_id.as_bytes().try_into()?});
+        Ok(V3OnionServiceId{data: service_id.as_bytes().try_into()?})
     }
 
     pub fn from_public_key(public_key: &Ed25519PublicKey) -> Result<V3OnionServiceId> {
@@ -395,7 +395,7 @@ impl V3OnionServiceId {
 
         let service_id = ONION_BASE32.encode(&raw_service_id);
 
-        return Ok(V3OnionServiceId{data:service_id.as_bytes().try_into()?});
+        Ok(V3OnionServiceId{data:service_id.as_bytes().try_into()?})
     }
 
     pub fn is_valid(service_id: &str) -> bool {
@@ -423,27 +423,27 @@ impl V3OnionServiceId {
                    truncated_checksum[1] != decoded_service_id[V3_ONION_SERVICE_ID_CHECKSUM_OFFSET + 1] {
                     return false;
                 }
-                return true;
+                true
             },
-            Err(_) => return false,
+            Err(_) => false,
         }
     }
 
     pub fn get_data(&self) -> &[u8] {
-        return &self.data;
+        &self.data
     }
 }
 
 impl PartialEq for V3OnionServiceId {
     fn eq(&self, other: &Self) -> bool {
-        return self.data.eq(&other.data);
+        self.data.eq(&other.data)
     }
 }
 
 impl ToString for V3OnionServiceId {
     fn to_string(&self) -> String {
         match str::from_utf8(&self.data) {
-            Ok(result) => return result.to_string(),
+            Ok(result) => result.to_string(),
             // this should really never ever happen but who knows
             Err(err) => panic!("{}", err),
         }
@@ -496,7 +496,7 @@ fn test_ed25519() -> Result<()> {
     let signature = private_key.sign_message(&message)?;
     assert!(signature.verify(&message, &public_key));
 
-    return Ok(());
+    Ok(())
 }
 
 #[test]
@@ -512,7 +512,7 @@ fn test_password_hash() -> Result<()> {
     // ensure same password is hashed to different things
     assert!(hash_tor_password("password")? != hash_tor_password("password")?);
 
-    return Ok(());
+    Ok(())
 }
 
 #[test]
@@ -536,5 +536,5 @@ fn test_x25519() -> Result<()> {
     let public_key = X25519PublicKey::from_private_key(&private_key);
     ensure!(public_key.to_base32() == PUBLIC_BASE32);
 
-    return Ok(());
+    Ok(())
 }

--- a/source/gosling/src/work_manager.rs
+++ b/source/gosling/src/work_manager.rs
@@ -258,17 +258,16 @@ impl WorkManager {
 
                 // we only need to store the result if
                 // the caller has saved off the TaskResult
-                if task_wait_handle.is_some() &&
-                   task_result.is_some() {
+                if let (Some(twait_handle), Some(tresult)) = (task_wait_handle, task_result) {
                     // box the closure result
                     let mut retval = Some(closure_result);
                     // swap in the result
                     std::mem::swap::<Option<Box<dyn Any + Send>>>(
                         &mut retval,
-                        &mut task_result.unwrap().lock().unwrap());
+                        &mut tresult.lock().unwrap());
 
                     // notify the task result
-                    task_wait_handle.unwrap().notify_one();
+                    twait_handle.notify_one();
                 }
             }
 


### PR DESCRIPTION
Remove unneded returns, borrows, question marsk and unwraps. And refactor manual memcpy and ptr_arg warnings.

Related to #22 