### PR TITLE
tor-interface: accept DegradedReachable as onion service published

### DIFF
--- a/source/gosling/crates/tor-interface/src/arti_client_tor_client.rs
+++ b/source/gosling/crates/tor-interface/src/arti_client_tor_client.rs
@@ -493,7 +493,7 @@ impl TorProvider for ArtiClientTorClient {
 
         self.tokio_runtime.spawn(async move {
             while let Some(evt) = status_events.next().await {
-                if evt.state() == tor_hsservice::status::State::Running {
+                if evt.state().is_fully_reachable() {
                     match pending_events.lock() {
                         Ok(mut pending_events) => {
                             pending_events.push(TorEvent::OnionServicePublished {


### PR DESCRIPTION
The onion service status handler only checked for State::Running, which requires all HSDir uploads to succeed. When some uploads fail the state settles at DegradedReachable (service is reachable, but not from every directory) and OnionServicePublished never fires.

Use is_fully_reachable() which accepts both Running and DegradedReachable, matching what the Arti developers intended.

Please take a look.