### PR TITLE
tor-interface: fall back to launch_onion_service on key reuse

### DIFF
--- a/source/gosling/crates/tor-interface/src/arti_client_tor_client.rs
+++ b/source/gosling/crates/tor-interface/src/arti_client_tor_client.rs
@@ -264,6 +264,70 @@ impl ArtiClientTorClient {
             .map_err(Error::TcpStreamIntoFailed)?;
         Ok::<std::net::TcpStream, tor_provider::Error>(client_stream)
     }
+
+    fn spawn_rend_handler(
+        runtime: &runtime::Runtime,
+        mut rend_requests: impl tokio_stream::Stream<Item = tor_hsservice::RendRequest> + Send + Unpin + 'static,
+        virt_port: u16,
+        socket_addr: SocketAddr,
+    ) {
+        // start a task which accepts every RendRequest to get a StreamRequest
+        runtime.spawn(async move {
+            while let Some(request) = rend_requests.next().await {
+                let mut stream_requests = match request.accept().await {
+                    Ok(stream_requests) => stream_requests,
+                    // TODO: probably not our problem?
+                    _ => return,
+                };
+                // spawn a new task to consume the stream requsts
+                tokio::task::spawn(async move {
+                    while let Some(stream_request) = stream_requests.next().await {
+                        let should_accept =
+                            if let IncomingStreamRequest::Begin(begin) = stream_request.request() {
+                                // we only accept connections on the virt port
+                                begin.port() == virt_port
+                            } else {
+                                false
+                            };
+
+                        if should_accept {
+                            let data_stream =
+                                match stream_request.accept(Connected::new_empty()).await {
+                                    Ok(data_stream) => data_stream,
+                                    // TODO: probably not our problem
+                                    _ => continue,
+                                };
+                            let (data_reader, data_writer) = data_stream.split();
+
+                            let (tcp_reader, tcp_writer) =
+                                match TcpStream::connect(socket_addr).await {
+                                    Ok(tcp_stream) => tcp_stream.into_split(),
+                                    // TODO: possibly our problem?
+                                    _ => continue,
+                                };
+                            // now spawn new tasks to forward traffic to/from the onion listener
+
+                            let pump_alive = Arc::new(AtomicBool::new(true));
+                            // read from connected client and write to local socket
+                            tokio::task::spawn({
+                                let pump_alive = pump_alive.clone();
+                                async move {
+                                    forward_stream(pump_alive, data_reader, tcp_writer).await;
+                                }
+                            });
+                            // read from local socket and write to connected client
+                            tokio::task::spawn(async move {
+                                forward_stream(pump_alive, tcp_reader, data_writer).await;
+                            });
+                        } else {
+                            // either requesting the wrong port or the wrong type of stream request
+                            let _ = stream_request.shutdown_circuit();
+                        }
+                    }
+                });
+            }
+        });
+    }
 }
 
 impl TorProvider for ArtiClientTorClient {
@@ -481,10 +545,28 @@ impl TorProvider for ArtiClientTorClient {
             Err(err) => Err(Error::OnionServiceConfigBuilderError(err))?,
         };
 
-        let (onion_service, mut rend_requests) = self
+        // launch_onion_service_with_hsid inserts the key with overwrite=false,
+        // so it fails with KeyAlreadyExists if the same service was previously
+        // launched (the key persists in the keystore after RunningOnionService
+        // is dropped).
+        // Fall back to launch_onion_service which reads the existing key.
+        let onion_service = match self
             .arti_client
-            .launch_onion_service_with_hsid(onion_service_config, hs_id_keypair.into())
-            .map_err(Error::ArtiClientOnionServiceLaunchError)?;
+            .launch_onion_service_with_hsid(onion_service_config.clone(), hs_id_keypair.into())
+        {
+            Ok((onion_service, rend_requests)) => {
+                Self::spawn_rend_handler(&self.tokio_runtime, rend_requests, virt_port, socket_addr);
+                onion_service
+            }
+            Err(_) => {
+                let (onion_service, rend_requests) = self
+                    .arti_client
+                    .launch_onion_service(onion_service_config)
+                    .map_err(Error::ArtiClientOnionServiceLaunchError)?;
+                Self::spawn_rend_handler(&self.tokio_runtime, rend_requests, virt_port, socket_addr);
+                onion_service
+            }
+        };
 
         // start a task to signal onion service published
         let pending_events = self.pending_events.clone();
@@ -506,63 +588,6 @@ impl TorProvider for ArtiClientTorClient {
                         ),
                     }
                 }
-            }
-        });
-
-        // start a task which accepts every RendRequest to get a StreamRequest
-        self.tokio_runtime.spawn(async move {
-            while let Some(request) = rend_requests.next().await {
-                let mut stream_requests = match request.accept().await {
-                    Ok(stream_requests) => stream_requests,
-                    // TODO: probably not our problem?
-                    _ => return,
-                };
-                // spawn a new task to consume the stream requsts
-                tokio::task::spawn(async move {
-                    while let Some(stream_request) = stream_requests.next().await {
-                        let should_accept =
-                            if let IncomingStreamRequest::Begin(begin) = stream_request.request() {
-                                // we only accept connections on the virt port
-                                begin.port() == virt_port
-                            } else {
-                                false
-                            };
-
-                        if should_accept {
-                            let data_stream =
-                                match stream_request.accept(Connected::new_empty()).await {
-                                    Ok(data_stream) => data_stream,
-                                    // TODO: probably not our problem
-                                    _ => continue,
-                                };
-                            let (data_reader, data_writer) = data_stream.split();
-
-                            let (tcp_reader, tcp_writer) =
-                                match TcpStream::connect(socket_addr).await {
-                                    Ok(tcp_stream) => tcp_stream.into_split(),
-                                    // TODO: possibly our problem?
-                                    _ => continue,
-                                };
-                            // now spawn new tasks to forward traffic to/from the onion listener
-
-                            let pump_alive = Arc::new(AtomicBool::new(true));
-                            // read from connected client and write to local socket
-                            tokio::task::spawn({
-                                let pump_alive = pump_alive.clone();
-                                async move {
-                                    forward_stream(pump_alive, data_reader, tcp_writer).await;
-                                }
-                            });
-                            // read from local socket and write to connected client
-                            tokio::task::spawn(async move {
-                                forward_stream(pump_alive, tcp_reader, data_writer).await;
-                            });
-                        } else {
-                            // either requesting the wrong port or the wrong type of stream request
-                            let _ = stream_request.shutdown_circuit();
-                        }
-                    }
-                });
             }
         });
 


### PR DESCRIPTION
launch_onion_service_with_hsid inserts the HSId key into the keystore with overwrite=false. When a RunningOnionService is dropped the key is not removed, so a second listener() call with the same private key fails with KeyAlreadyExists.

Fall back to launch_onion_service which reads the existing key from the keystore instead of inserting a new one. Extract the rend-request handler into spawn_rend_handler so both code paths can use it (they return different opaque Stream types).

> [!NOTE]
> This is larger than it would be if it were in arti-client. If there, it would be a single line change [here](https://gitlab.torproject.org/tpo/core/arti/-/blob/35ecc0896dfcea19692004341a0d5c3a5167e142/crates/arti-client/src/client.rs#L1810).
> ```diff
> diff --git a/.../client.rs b/.../client.rs
> --- a/.../client.rs
> +++ b/.../client.rs
> @@ -1807,7 +1807,7 @@ impl<R: Runtime> TorClient<R> {
>              .ok_or(ErrorDetail::KeystoreRequired {
>                  action: "launch onion service ex",
>              })?
> -            .insert::<HsIdKeypair>(id_keypair, &hsid_spec, selector, false)?;
> +            .insert::<HsIdKeypair>(id_keypair, &hsid_spec, selector, true)?;
>  
>          self.launch_onion_service(config)
>      }
> ```
> I'm not sure of the broader implications of making that change there, so I made the the workaround here.